### PR TITLE
Builds: use Conda to build on build-large queue

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -3,18 +3,13 @@ version: 2
 formats: []
 
 sphinx:
-  # At this moment, the builder has to match to the DB setting from
-  # "Advanced settings" because otherwise we will receive a build
-  # error. This behavior could probably change in the future to take
-  # precedence by the YAML config. More context on this at
-  # https://github.com/rtfd/readthedocs.org/issues/4638
-  builder: html
-
   configuration: conf.py
   fail_on_warning: false
 
-python:
-  version: 3.6
+build:
+  os: ubuntu-22.04
+  tools:
+    python: miniconda3-4.7
 
 conda:
     environment: environment.yml


### PR DESCRIPTION
Use Mamba to check build-large queue.

Related #9
Related readthedocs/readthedocs.org#9527